### PR TITLE
Allow clients to subscribe to setReport calls on devices

### DIFF
--- a/examples/u2f.c
+++ b/examples/u2f.c
@@ -1,0 +1,203 @@
+/**
+ * Create a virtual U2F device.
+ * Compile me with: gcc u2f.c -o virtual_u2f -framework IOKit
+ */
+
+#include <IOKit/IOKitLib.h>
+#include <CoreFoundation/CFRunLoop.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "foohid_types.h"
+
+unsigned char report_descriptor[] = {
+    0x06, 0xD0, 0xF1,  // Usage Page (Reserved 0xF1D0)
+    0x09, 0x01,        // Usage (0x01)
+    0xA1, 0x01,        // Collection (Application)
+    0x09, 0x20,        //   Usage (0x20)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8)
+    0x95, 0x40,        //   Report Count (64)
+    0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x09, 0x21,        //   Usage (0x21)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8)
+    0x95, 0x40,        //   Report Count (64)
+    0x91, 0x02,        //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              // End Collection
+};
+
+#define SERVICE_NAME "it_unbit_foohid"
+
+#define FOOHID_CREATE  0 // create selector
+#define FOOHID_DESTROY 1 // destroy selector
+#define FOOHID_SEND    2 // send selector
+#define FOOHID_LIST    3 // list selector
+#define FOOHID_NOTIFY  4 // notify selector
+
+#define DEVICE_NAME "Foohid Virtual U2F Device"
+#define DEVICE_SN "SN 123456"
+
+io_connect_t foohid_connect;
+CFRunLoopRef run_loop = NULL;
+
+void cleanup(int sig) {
+    kern_return_t ret;
+    
+    printf("Cleaning up...\n");
+    
+    if (run_loop)
+      CFRunLoopStop(run_loop);
+
+    // Destroy the device we created.
+    uint32_t destroy_count = 2;
+    uint64_t destroy[destroy_count];
+    destroy[0] = (uint64_t) strdup(DEVICE_NAME); // device name
+    destroy[1] = strlen((char *)destroy[0]);     // name length
+
+    ret = IOConnectCallScalarMethod(foohid_connect, FOOHID_DESTROY, destroy, destroy_count, NULL, NULL);
+    if (ret != KERN_SUCCESS) {
+        printf("Unable to destroy HID device. May be fine if it wasn't created.\n");
+    }
+
+    // Close our connection to the user client.
+    IOServiceClose(foohid_connect);
+
+    exit(0);
+}
+
+void callback(void *refcon, IOReturn result, io_user_reference_t* args, uint32_t numArgs) {
+  foohid_report *report;
+
+  printf("callback called.\n");
+
+  if (sizeof(io_user_reference_t) * numArgs != sizeof(foohid_report)) {
+      printf("unexpected number of arguments.\n");
+      return;
+  }
+
+  report = (foohid_report *)args;
+  printf("received report (%llu bytes).\n", report->size);
+}
+
+void run() {
+  IONotificationPortRef notification_port;
+  mach_port_t mnotification_port;
+  CFRunLoopSourceRef run_loop_source;
+  io_async_ref64_t async_ref;
+  kern_return_t ret;
+
+  // Create port to listen for kernel notifications on.
+  notification_port = IONotificationPortCreate(kIOMasterPortDefault);
+  if (!notification_port) {
+    printf("Error getting notification port.\n");
+    return;
+  }
+
+  // Get lower level mach port from notification port.
+  mnotification_port = IONotificationPortGetMachPort(notification_port);
+  if (!mnotification_port) {
+    printf("Error getting mach notification port.\n");
+    return;
+  }
+
+  // Create a run loop source from our notification port so we can add the port to our run loop.
+  run_loop_source = IONotificationPortGetRunLoopSource(notification_port);
+  if (run_loop_source == NULL) {
+    printf("Error getting run loop source.\n");
+    return;
+  }
+
+  // Add the notification port and timer to the run loop.
+  CFRunLoopAddSource(CFRunLoopGetCurrent(), run_loop_source, kCFRunLoopDefaultMode);
+
+  // Params to pass to the kernel.
+  async_ref[kIOAsyncCalloutFuncIndex] = (uint64_t)callback;
+  async_ref[kIOAsyncCalloutRefconIndex] = 0;
+  
+  uint32_t sub_count = 2;
+  uint64_t sub[sub_count];
+  sub[0] = (uint64_t) strdup(DEVICE_NAME); // device name
+  sub[1] = strlen((char *)sub[0]);     // name length
+
+  // Tell the kernel how to notify us.
+  ret = IOConnectCallAsyncScalarMethod(foohid_connect, FOOHID_NOTIFY, mnotification_port, async_ref, kIOAsyncCalloutCount, sub, sub_count, NULL, 0);
+  if (ret != kIOReturnSuccess) {
+    printf("Error registering for setFrame notifications.\n");
+    return;
+  }
+
+  // Blocks until the run loop is stopped in our callback.
+  printf("Starting async run loop.\n");
+  run_loop = CFRunLoopGetCurrent();
+  CFRunLoopRun();
+  run_loop = NULL;
+
+  // Clean up.
+  IONotificationPortDestroy(notification_port);
+}
+
+int main() {
+    io_iterator_t iterator;
+    io_service_t service;
+
+    // Get a reference to the IOService
+    kern_return_t ret = IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching(SERVICE_NAME), &iterator);
+
+    if (ret != KERN_SUCCESS) {
+        printf("Unable to access IOService.\n");
+        exit(1);
+    }
+
+    // Iterate till success
+    int found = 0;
+    while ((service = IOIteratorNext(iterator)) != IO_OBJECT_NULL) {
+        ret = IOServiceOpen(service, mach_task_self(), 0, &foohid_connect);
+
+        if (ret == KERN_SUCCESS) {
+            found = 1;
+            break;
+        }
+
+        IOObjectRelease(service);
+    }
+    IOObjectRelease(iterator);
+
+    if (!found) {
+        printf("Unable to open IOService.\n");
+        cleanup(0);
+        exit(1);
+    }
+
+    // Register handler for interrupts.
+    signal(SIGHUP, cleanup);
+    signal(SIGINT, cleanup);
+    signal(SIGQUIT, cleanup);
+    signal(SIGTERM, cleanup);
+    signal(SIGKILL, cleanup);
+
+    // Fill up the input arguments for device creation.
+    uint32_t create_count = 8;
+    uint64_t create[create_count];
+    create[0] = (uint64_t) strdup(DEVICE_NAME);  // device name
+    create[1] = strlen((char *)create[0]);  // name length
+    create[2] = (uint64_t) report_descriptor;  // report descriptor
+    create[3] = sizeof(report_descriptor);  // report descriptor len
+    create[4] = (uint64_t) strdup(DEVICE_SN);  // serial number
+    create[5] = strlen((char *)create[4]);  // serial number len
+    create[6] = (uint64_t) 2;  // vendor ID
+    create[7] = (uint64_t) 3;  // device ID
+
+    // Create HID device.
+    ret = IOConnectCallScalarMethod(foohid_connect, FOOHID_CREATE, create, create_count, NULL, NULL);
+    if (ret != KERN_SUCCESS) {
+        printf("Unable to create HID device. May be fine if created previously.\n");
+    }
+    
+    printf("Starting run loop.\n");
+    run();
+    printf("Run loop stopped.\n");
+}

--- a/foohid.xcodeproj/project.pbxproj
+++ b/foohid.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		517FF7E71E45107D00DD60EE /* foohid_types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = foohid_types.h; sourceTree = "<group>"; };
 		625BDE461AA6EE98001573B2 /* foohid.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = foohid.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		625BDE4A1AA6EE98001573B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		625BDE4B1AA6EE98001573B2 /* foohid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = foohid.h; sourceTree = "<group>"; };
@@ -58,6 +59,7 @@
 			isa = PBXGroup;
 			children = (
 				764F7B221BB9AE4F005252AF /* debug.h */,
+				517FF7E71E45107D00DD60EE /* foohid_types.h */,
 				625BDE581AA7034B001573B2 /* foohid_device.cpp */,
 				625BDE591AA7034B001573B2 /* foohid_device.h */,
 				625BDE541AA6F19A001573B2 /* foohid_userclient.cpp */,

--- a/foohid/foohid.cpp
+++ b/foohid/foohid.cpp
@@ -270,3 +270,33 @@ bool it_unbit_foohid::methodList(char *buf, UInt16 buf_len,
     if (*needed != 0) return false;
     return true;
 }
+
+bool it_unbit_foohid::methodSubscribe(char *name, UInt8 name_len, IOService *userClient) {
+    OSString *key = nullptr;
+    it_unbit_foohid_device *device = nullptr;
+
+    if (name_len == 0) return false;
+
+    {
+        char *cname = (char *)IOMalloc(name_len + 1);
+        if (!cname) return false;
+        memcpy(cname, name, name_len);
+        cname[name_len] = 0;
+        key = OSString::withCString(cname);
+        IOFree(cname, name_len + 1);
+    }
+    if (!key) goto end;
+
+    device = (it_unbit_foohid_device *)m_hid_devices->getObject(key);
+    if (!device) goto end;
+
+    device->subscribe(userClient);
+
+    key->release();
+
+    return true;
+
+end:
+    if (key) key->release();
+    return false;
+}

--- a/foohid/foohid.h
+++ b/foohid/foohid.h
@@ -1,3 +1,6 @@
+#ifndef foohid_h
+#define foohid_h
+
 #include <IOKit/IOService.h>
 
 class it_unbit_foohid : public IOService {
@@ -66,10 +69,23 @@ public:
      */
     virtual bool methodList(char *buf, UInt16 buf_len,
                             UInt16 *needed, UInt16 *items);
-    
+
+    /**
+     *  Subscribe userclient to setReport calls on the given device.
+     *
+     *  @param name       A unique device name.
+     *  @param name_len   Length of 'name'.
+     *  @param userClient UserClient that is subscribing.
+     *
+     *  @return True on success.
+     */
+    virtual bool methodSubscribe(char *name, UInt8 name_len, IOService *userClient);
+
 private:
     /**
      *  Keep track of managed/created HID devices.
      */
     OSDictionary *m_hid_devices;
 };
+
+#endif

--- a/foohid/foohid_device.cpp
+++ b/foohid/foohid_device.cpp
@@ -46,6 +46,10 @@ OSString *it_unbit_foohid_device::name() {
     return m_name;
 }
 
+void it_unbit_foohid_device::subscribe(IOService *userClient) {
+    m_user_client = OSDynamicCast(it_unbit_foohid_userclient, userClient);
+}
+
 void it_unbit_foohid_device::setName(OSString *name) {
     if (name) name->retain();
     m_name = name;
@@ -81,6 +85,13 @@ IOReturn it_unbit_foohid_device::newReportDescriptor(IOMemoryDescriptor **descri
     *descriptor = buffer;
     
     return kIOReturnSuccess;
+}
+
+IOReturn it_unbit_foohid_device::setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) {
+    // No one is listening yet.
+    if (!m_user_client) return kIOReturnSuccess;
+
+    return m_user_client->notifySubscriber(report);
 }
 
 OSString *it_unbit_foohid_device::newProductString() const {

--- a/foohid/foohid_device.h
+++ b/foohid/foohid_device.h
@@ -1,4 +1,8 @@
+#ifndef foohid_device_h
+#define foohid_device_h
+
 #include "IOKit/hid/IOHIDDevice.h"
+#include "foohid_userclient.h"
 
 class it_unbit_foohid_device : public IOHIDDevice {
     OSDeclareDefaultStructors(it_unbit_foohid_device)
@@ -46,6 +50,13 @@ public:
      *  @return The device name.
      */
     virtual OSString *name();
+
+    /**
+     *  Store a callback to be called whenever setReport is called on device.
+     *
+     *  @param subscriber Reference to callback.
+     */
+    virtual void subscribe(IOService *userClient);
     
     virtual OSString *newProductString() const override;
     virtual OSString *newSerialNumberString() const override;
@@ -53,7 +64,10 @@ public:
     virtual OSNumber *newProductIDNumber() const override;
     
     virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const override;
-    
+
+    virtual IOReturn setReport(IOMemoryDescriptor *report, IOHIDReportType reportType,
+                               IOOptionBits options = 0) override;
+
     unsigned char *reportDescriptor = nullptr;
     UInt16 reportDescriptor_len;
     
@@ -64,4 +78,7 @@ private:
     OSString *m_serial_number_string = nullptr;
     OSNumber *m_vendor_id = nullptr;
     OSNumber *m_product_id = nullptr;
+    it_unbit_foohid_userclient *m_user_client = nullptr;
 };
+
+#endif

--- a/foohid/foohid_types.h
+++ b/foohid/foohid_types.h
@@ -1,0 +1,19 @@
+//
+//  foohid_types.h
+//  foohid
+//
+//  Created by Benjamin P Toews on 2/3/17.
+//  Copyright © 2017 unbit. All rights reserved.
+//
+
+#ifndef foohid_types_h
+#define foohid_types_h
+
+const uint8_t foohid_max_report = 64;
+
+typedef struct foohid_report {
+    uint64_t size;
+    uint8_t data[foohid_max_report];
+} foohid_report;
+
+#endif

--- a/foohid/foohid_userclient.h
+++ b/foohid/foohid_userclient.h
@@ -1,3 +1,6 @@
+#ifndef foohid_userclient_h
+#define foohid_userclient_h
+
 #include <IOKit/IOService.h>
 #include <IOKit/IOUserClient.h>
 
@@ -11,7 +14,8 @@ enum {
     it_unbit_foohid_method_destroy,
     it_unbit_foohid_method_send,
     it_unbit_foohid_method_list,
-    
+    it_unbit_foohid_method_subscribe,
+
     it_unbit_foohid_method_count  // Keep track of the length of this enum.
 };
 
@@ -29,7 +33,9 @@ public:
                                     IOExternalMethodArguments *arguments,
                                     IOExternalMethodDispatch *dispatch,
                                     OSObject *target, void *reference) override;
-    
+
+    virtual IOReturn notifySubscriber(IOMemoryDescriptor *report);
+
 protected:
     /**
      * The following methods unpack/handle the given arguments and 
@@ -39,7 +45,8 @@ protected:
     virtual IOReturn methodDestroy(IOExternalMethodArguments *arguments);
     virtual IOReturn methodSend(IOExternalMethodArguments *arguments);
     virtual IOReturn methodList(IOExternalMethodArguments *arguments);
-    
+    virtual IOReturn methodSubscribe(IOExternalMethodArguments *arguments);
+
     /**
      *  The following static methods redirect the call to the 'target' instance.
      */
@@ -55,7 +62,10 @@ protected:
     static IOReturn sMethodList(it_unbit_foohid_userclient *target,
                                void *reference,
                                IOExternalMethodArguments *arguments);
-    
+    static IOReturn sMethodSubscribe(it_unbit_foohid_userclient *target,
+                                    void *reference,
+                                    IOExternalMethodArguments *arguments);
+
 private:
     /**
      *  Method dispatch table.
@@ -66,9 +76,16 @@ private:
      *  Driver provider.
      */
     it_unbit_foohid *m_hid_provider;
+
+    /**
+     *  Userland subscriber.
+     */
+    OSAsyncReference64 *m_subscriber = nullptr;
     
     /**
      *  Task owner.
      */
     task_t m_owner;
 };
+
+#endif


### PR DESCRIPTION
This PR implements the `setReport()` method on the foohid device. This gets called when a report needs to be sent back to the device by whatever client is using it. To get these reports back into userland, this PR implements an external userclient method for subscribing to `setReport` calls for a given device. The subscribe method registers a callback function that gets called from the userclient when a device receives a `setReport()` call. This approach allows the userland HID implementation to receive `setReport()` calls without having to constantly poll the userclient.

I'm copying this approach from the [SoftU2F driver](https://github.com/mastahyeti/SoftU2F) I wrote. I'm hoping to include this change in foohid because Apple hasn't responded to my request for a kernel extension signing certificate.

I added a simple U2F example to this repository to demonstrate subscribing to `setReport()` calls.

Fixes #7